### PR TITLE
Imágenes ajustadas

### DIFF
--- a/src/app/views/components/speaker-card/speaker-card.component.html
+++ b/src/app/views/components/speaker-card/speaker-card.component.html
@@ -2,7 +2,7 @@
   <div class="inline-flex shadow-lg border border-gray-200 rounded-full overflow-hidden h-40 w-40">
     <img [src]="speaker.photoUrl"
        [alt]="speaker.name"
-       class="h-full w-full">
+       class="h-full w-full object-cover">
   </div>
 
   <h2 class="mt-4 font-bold text-xl">{{speaker.name}}</h2>


### PR DESCRIPTION
Si va a https://ng-honduras.org/speakers y revisa las fotos de los speakers, hay algunos que tienen la foto desfigurada, esto pasa porque se espera que la foto tenga el mismo width y height, pero si no lo es se intenta ajustar y no se ven bien.

La solución ( ya que se usa tailwind css ) es añadir la clase object-cover en la imagen en `src/app/views/components/speaker-card/speaker-card.component.html:5`

Aquí un antes y un después de ese cambio
Antes:
<img width="1260" alt="Antes" src="https://user-images.githubusercontent.com/18739832/109874230-7485c700-7c34-11eb-9932-140a75952bf8.png">

Después:
<img width="1233" alt="Después" src="https://user-images.githubusercontent.com/18739832/109874249-78194e00-7c34-11eb-939a-77c2e59548a1.png">

